### PR TITLE
reuse clients and set transport

### DIFF
--- a/proxy/proxy.yaml
+++ b/proxy/proxy.yaml
@@ -50,6 +50,11 @@ metadata:
         proxyTimeout: "100"
         idleTimeout: "10"
         debugLevel: "1"
+        maxIdleConns: "2000"
+        maxIdleConnsPerHost: "2000"
+        maxConnsPerHost: "700"
+        idleConnTimeout: "90"
+        tlsHandshakeTimeout: "10"
 spec:
     selector:
         matchLabels:


### PR DESCRIPTION
Made some changes so that proxy re-use the client to send events. I'll also need to look into what InsecureSkipVerify does. Currently all events have that as false, but any events have InsecureSkipVerify as true. Then client transport gets reset. 